### PR TITLE
FloorQuality Stat

### DIFF
--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -37,6 +37,9 @@
   <RSID_StorageSpace>Max stacks stored: {0}</RSID_StorageSpace>
   <RSID_DefName>DefName: {0}</RSID_DefName>
   <RSID_DominantStyle>Dominant style: {0}</RSID_DominantStyle>
+  <RSID_FloorQuality>Floor Quality: {0}</RSID_FloorQuality>
+  <RSID_FloorQuality_Fine>Fine</RSID_FloorQuality_Fine>
+  <RSID_FloorQuality_Common>Common</RSID_FloorQuality_Common>
   <!-- Settings -->
   <RSID_ShowHP.Label>Show max HP for linkable structures and doors</RSID_ShowHP.Label>
   <RSID_ShowHP.Tooltip>Shows the maximum hitpoints for structures such as walls, fences, doors and sandbags</RSID_ShowHP.Tooltip>
@@ -88,6 +91,8 @@
   <RSID_VariedPowerModLoaded.Tooltip>There is a mod active that modifies power-draw of items when they are not in use (Turn It On and Off - RePowered or LightsOut). If you change the settings regarding power in any of these mods, reopen this settings page after to clear the cached powervalues in the descriptions. If not you will not see the updated values in game.</RSID_VariedPowerModLoaded.Tooltip>
   <RSID_ShowPowerProducer.Label>Show power production</RSID_ShowPowerProducer.Label>
   <RSID_ShowPowerProducer.Tooltip>Will show the maximum power-production of any building that produces power</RSID_ShowPowerProducer.Tooltip>
+  <RSID_ShowFloorQuality.Label>Show floor quality</RSID_ShowFloorQuality.Label>
+  <RSID_ShowFloorQuality.Tooltip>Will show if the floor is of fine quality for royalty, or only acceptable for common pawns.</RSID_ShowFloorQuality.Tooltip>
   <RSID_ShowDefName.Label>Show defName</RSID_ShowDefName.Label>
   <RSID_ShowDefName.Tooltip>Will show the defname of all buildables</RSID_ShowDefName.Tooltip>
   <RSID_ShowDominantStyle.Label>Show dominant style</RSID_ShowDominantStyle.Label>

--- a/Source/RelevantStatsInDescription/RelevantStatsInDescription.cs
+++ b/Source/RelevantStatsInDescription/RelevantStatsInDescription.cs
@@ -241,6 +241,13 @@ public class RelevantStatsInDescription
                 }
             }
 
+            // Floor Quality (Royalty)
+            if (RelevantStatsInDescriptionMod.instance.RelevantStatsInDescriptionSettings.ShowFloorQuality && ModsConfig.RoyaltyActive)
+            {
+                var floorQuality = floorDef.IsFine ? "RSID_FloorQuality_Fine".Translate() : "RSID_FloorQuality_Common".Translate();
+                arrayToAdd.Add("RSID_FloorQuality".Translate(floorQuality));
+            }
+
             // Defname
             if (RelevantStatsInDescriptionMod.instance.RelevantStatsInDescriptionSettings.ShowDefName)
             {

--- a/Source/RelevantStatsInDescription/RelevantStatsInDescriptionMod.cs
+++ b/Source/RelevantStatsInDescription/RelevantStatsInDescriptionMod.cs
@@ -177,6 +177,9 @@ internal class RelevantStatsInDescriptionMod : Mod
             RelevantStatsInDescriptionSettings.RelativeWork = false;
         }
 
+        listing_Standard.CheckboxLabeled("RSID_ShowFloorQuality.Label".Translate(),
+            ref RelevantStatsInDescriptionSettings.ShowFloorQuality,
+            "RSID_ShowFloorQuality.Tooltip".Translate());
         listing_Standard.CheckboxLabeled("RSID_ShowDefName.Label".Translate(),
             ref RelevantStatsInDescriptionSettings.ShowDefName,
             "RSID_ShowDefName.Tooltip".Translate());

--- a/Source/RelevantStatsInDescription/RelevantStatsInDescriptionSettings.cs
+++ b/Source/RelevantStatsInDescription/RelevantStatsInDescriptionSettings.cs
@@ -38,6 +38,7 @@ internal class RelevantStatsInDescriptionSettings : ModSettings
     public bool ShowVFEGas = true;
     public bool ShowWealth = true;
     public bool ShowWorkToBuild = true;
+    public bool ShowFloorQuality = true;
     public bool UseTooltip;
 
     /// <summary>
@@ -78,5 +79,6 @@ internal class RelevantStatsInDescriptionSettings : ModSettings
         Scribe_Values.Look(ref ShowDefName, "ShowDefName");
         Scribe_Values.Look(ref RemoveRotateWidget, "RemoveRotateWidget", true);
         Scribe_Values.Look(ref ShowDominantStyle, "ShowDominantStyle", true);
+        Scribe_Values.Look(ref ShowFloorQuality, "ShowFloorQuality", true);
     }
 }


### PR DESCRIPTION
Adds a stat for TerrainDefs to output the result of `IsFine` (aka, does it have the tag "FineFloor"). "Fine" floors are required for setting up Royalty thronerooms and bedrooms, and with many mods, it is not always easy to tell what is or is not considered "fine". The data is already exposed in-game in the Info tab, where it shows "Considered: Fine" for fine floors (and "Considered" doesn't show up for non-fine ones).

I compiled and ran this in a low-mod situation (basically this and Harmony), one with just a bunch of floor-adding mods, and then in my large modlist save, and haven't had any issues. I tried doing a pre- and post- change comparison in Dubs Performance Analyzer, but it didn't really move the needle at all. 